### PR TITLE
Fix markdown format in readme

### DIFF
--- a/golang/README.md
+++ b/golang/README.md
@@ -2,18 +2,18 @@
 
 1. Build image
 
-```bash
-sudo docker build -t="<image name>" .
-```
+  ```bash
+  sudo docker build -t="<image name>" .
+  ```
 
 2. Check go runtime & version
 
-```bash
-sudo docker run -i -t <image name>
-```
+  ```bash
+  sudo docker run -i -t <image name>
+  ```
 
-2. Run container
+3. Run container
 
-```bash
-sudo docker run -d -t -p <expose port> -v /path/to/gopath/src:/projects/golang/src <image name> <go command & params> 
-```
+  ```bash
+  sudo docker run -d -t -p <expose port> -v /path/to/gopath/src:/projects/golang/src <image name> <go command & params>
+  ```

--- a/redis/README.md
+++ b/redis/README.md
@@ -2,24 +2,24 @@
 
 1. Build image
 
-```bash
-sudo docker build -t="<image name>" .
-```
+  ```bash
+  sudo docker build -t="<image name>" .
+  ```
 
 2. Run container
 
-```bash
-sudo docker run -d -t -p 6379 -v /path/to/redis/config/file:/opt/conf <image name> /opt/conf/redis.conf
-```
+  ```bash
+  sudo docker run -d -t -p 6379 -v /path/to/redis/config/file:/opt/conf <image name> /opt/conf/redis.conf
+  ```
 
 3. Check redis status
 
-```bash
-sudo docker exec -i <image name> ps aux | grep redis
-```
+  ```bash
+  sudo docker exec -i <image name> ps aux | grep redis
+  ```
 
 4. Connect redis
 
-```bash
-redis-cli -p `sudo docker port <image name> 6379 | awk -F":" '{print $2}'`
-```
+  ```bash
+  redis-cli -p `sudo docker port <image name> 6379 | awk -F":" '{print $2}'`
+  ```


### PR DESCRIPTION
In markdown, the `1.` and `2.` always start with one. So we should `tag` the sub content after them.
